### PR TITLE
Set up GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  code-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: zulu
+          cache: 'gradle'
+
+      - name: Check Code Formatting
+        run: ./gradlew spotlessCheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release Library
+name: Publish Library
 
 on:
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Release Library
 
 on:
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Release Library
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-library-to-maven:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: zulu
+          cache: 'gradle'
+
+      - name: Publish Library to Maven
+        run: ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache


### PR DESCRIPTION
Add 2 GH Actions

- CI Checks
- Publish library to Maven

Since there are no tests, at the moment CI checks only check for code formatting.

For publishing library GH Action, you do need to add these env variables in settings.
```
ORG_GRADLE_PROJECT_mavenCentralUsername=username
ORG_GRADLE_PROJECT_mavenCentralPassword=the_password

# see below for how to obtain this
ORG_GRADLE_PROJECT_signingInMemoryKey=exported_ascii_armored_key
# Optional
ORG_GRADLE_PROJECT_signingInMemoryKeyId=12345678
# If key was created with a password.
ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=some_password
```
[more info](https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets)

I was thinking of providing the version number as an input parameter as input to the publishing workflow. But wasn't sure if that's required or not, so skipped it for now.